### PR TITLE
Fix invalid line in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,8 +3,7 @@ version=1.4.1
 author=Mike McCauley <https://groups.google.com/forum/#!forum/radiohead-arduino>, SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=This is the RadioHead Packet Radio library for embedded microprocessors.
-paragraph=It provides a complete object-oriented library for sending and receiving packetized messages via a variety of common data radios and other transports on a range of embedded microprocessors.Drivers provide low level access to a range of different packet radios and other packetized message transports.
-Managers provide high level message sending and receiving facilities for a range of different requirements.
+paragraph=It provides a complete object-oriented library for sending and receiving packetized messages via a variety of common data radios and other transports on a range of embedded microprocessors.Drivers provide low level access to a range of different packet radios and other packetized message transports. Managers provide high level message sending and receiving facilities for a range of different requirements.
 category=Communication
 url=https://github.com/sparkfun/SparkFun_RadioHead_Arduino_Library
 architectures=*


### PR DESCRIPTION
Each line in library.properties must either contain an '=', start with a #, or be whitespace. Installation of a library with an invalid line will cause compilation of any code (even if it doesn't #include the library) to fail:

Property line '...' in file ... is invalid

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format